### PR TITLE
Refactor Survey Resource to streamline survey creation process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,4 +107,4 @@ public function panel(Panel $panel): Panel
 }
 ```
 
-That's it! Now the surveys, sections, questions, answers, and entries resources will be displayed in the left sidebar in your Filament admin panel.
+That's it! Now the surveys, answers, and entries resources will be displayed in the left sidebar in your Filament admin panel. To enable dedicated resources for Sections, and Questions, publish the config and add QuestionResource and SectionResource to the 'resources' array.

--- a/config/filament-survey.php
+++ b/config/filament-survey.php
@@ -5,8 +5,6 @@ return [
     'resources' => [
         'AnswerResource' => \Tapp\FilamentSurvey\Resources\AnswerResource::class,
         'EntryResource' => \Tapp\FilamentSurvey\Resources\EntryResource::class,
-        'QuestionResource' => \Tapp\FilamentSurvey\Resources\QuestionResource::class,
-        'SectionResource' => \Tapp\FilamentSurvey\Resources\SectionResource::class,
         'SurveyResource' => \Tapp\FilamentSurvey\Resources\SurveyResource::class,
     ],
 

--- a/src/Exports/SurveysExport.php
+++ b/src/Exports/SurveysExport.php
@@ -3,24 +3,36 @@
 namespace Tapp\FilamentSurvey\Exports;
 
 use Illuminate\Support\Facades\DB;
-use Maatwebsite\Excel\Concerns\FromCollection;
-use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMapping;
+use Illuminate\Database\Eloquent\Collection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use MattDaneshvar\Survey\Models\Survey;
+
 
 class SurveysExport implements FromCollection, WithHeadings, WithMapping
 {
+    public ?Collection $surveys;
+    public ?Survey $survey;
+
+    public function __construct(?Collection $surveys = null, Survey $survey = null)
+    {
+        $this->surveys = $surveys;
+        $this->survey = $survey;
+    }
+
     /**
      * @return \Illuminate\Support\Collection
      */
     public function collection()
     {
-        return collect(DB::select(DB::raw("
+        $rawExpression = "
             SELECT
                 users.name as user_name,
                 users.email as user_email,
                 JSON_EXTRACT(surveys.name, '$.en') as survey_name,
                 JSON_EXTRACT(questions.content, '$.en') as question_content,
-                JSON_EXTRACT(answers.value, '$.en') as answer_value,
+                answers.value as answer_value,
                 entries.created_at as entry_created_at
             FROM
                 answers
@@ -28,7 +40,21 @@ class SurveysExport implements FromCollection, WithHeadings, WithMapping
                 JOIN entries ON entries.id = answers.entry_id
                 JOIN surveys ON surveys.id = entries.survey_id
                 JOIN users ON users.id = entries.participant_id
-        ")));
+        ";
+
+        if ($this->survey) {
+            $rawExpression = $rawExpression.' where surveys.id = '.$this->survey->id;
+        }
+
+        if ($this->surveys) {
+            $surveyIdsString = implode(', ', $this->surveys->pluck('id')->toArray());
+            $rawExpression = $rawExpression.' where surveys.id In ('.$surveyIdsString.')';
+        }
+
+        $expression = DB::raw($rawExpression)
+            ->getValue(DB::connection()->getQueryGrammar());
+
+        return collect(DB::select($expression));
     }
 
     public function map($survey): array

--- a/src/Exports/SurveysExport.php
+++ b/src/Exports/SurveysExport.php
@@ -2,20 +2,20 @@
 
 namespace Tapp\FilamentSurvey\Exports;
 
-use Illuminate\Support\Facades\DB;
-use Maatwebsite\Excel\Concerns\WithMapping;
 use Illuminate\Database\Eloquent\Collection;
-use Maatwebsite\Excel\Concerns\WithHeadings;
+use Illuminate\Support\Facades\DB;
 use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithMapping;
 use MattDaneshvar\Survey\Models\Survey;
-
 
 class SurveysExport implements FromCollection, WithHeadings, WithMapping
 {
     public ?Collection $surveys;
+
     public ?Survey $survey;
 
-    public function __construct(?Collection $surveys = null, Survey $survey = null)
+    public function __construct(?Collection $surveys = null, ?Survey $survey = null)
     {
         $this->surveys = $surveys;
         $this->survey = $survey;

--- a/src/FilamentSurveyServiceProvider.php
+++ b/src/FilamentSurveyServiceProvider.php
@@ -20,7 +20,5 @@ class FilamentSurveyServiceProvider extends PackageServiceProvider
     public function packageBooted(): void
     {
         parent::packageBooted();
-
-        //
     }
 }

--- a/src/Jobs/SendExportSurveys.php
+++ b/src/Jobs/SendExportSurveys.php
@@ -3,16 +3,16 @@
 namespace Tapp\FilamentSurvey\Jobs;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Mail;
 use Maatwebsite\Excel\Facades\Excel;
-use Tapp\FilamentSurvey\Mail\Export;
-use Illuminate\Queue\SerializesModels;
 use MattDaneshvar\Survey\Models\Survey;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Database\Eloquent\Collection;
 use Tapp\FilamentSurvey\Exports\SurveysExport;
+use Tapp\FilamentSurvey\Mail\Export;
 
 class SendExportSurveys implements ShouldQueue
 {
@@ -24,6 +24,7 @@ class SendExportSurveys implements ShouldQueue
     public $user;
 
     public ?Collection $surveys;
+
     public ?Survey $survey;
 
     /**

--- a/src/Jobs/SendExportSurveys.php
+++ b/src/Jobs/SendExportSurveys.php
@@ -3,14 +3,16 @@
 namespace Tapp\FilamentSurvey\Jobs;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Mail;
 use Maatwebsite\Excel\Facades\Excel;
-use Tapp\FilamentSurvey\Exports\SurveysExport;
 use Tapp\FilamentSurvey\Mail\Export;
+use Illuminate\Queue\SerializesModels;
+use MattDaneshvar\Survey\Models\Survey;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Database\Eloquent\Collection;
+use Tapp\FilamentSurvey\Exports\SurveysExport;
 
 class SendExportSurveys implements ShouldQueue
 {
@@ -21,14 +23,19 @@ class SendExportSurveys implements ShouldQueue
 
     public $user;
 
+    public ?Collection $surveys;
+    public ?Survey $survey;
+
     /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct($user)
+    public function __construct($user, $survey = null, $surveys = null)
     {
         $this->user = $user;
+        $this->survey = $survey;
+        $this->surveys = $surveys;
     }
 
     /**
@@ -39,9 +46,17 @@ class SendExportSurveys implements ShouldQueue
     public function handle()
     {
         $filename = now()->format('Y-m-d_his').'-surveys.xlsx';
-        $subject = __('Export ready:').' '.$filename;
 
-        $export = Excel::download(new SurveysExport(), $filename)->getFile();
+        if ($this->survey) {
+            $filename = now()->format('Y-m-d_his').'-'.urlencode($this->survey->name).'.xlsx';
+            $export = Excel::download(new SurveysExport(survey: $this->survey), $filename)->getFile();
+        } elseif ($this->surveys) {
+            $export = Excel::download(new SurveysExport(surveys: $this->surveys), $filename)->getFile();
+        } else {
+            $export = Excel::download(new SurveysExport(), $filename)->getFile();
+        }
+
+        $subject = __('Export ready:').' '.$filename;
 
         Mail::to($this->user->email)->send(new Export($export, $filename, $subject));
     }

--- a/src/Resources/QuestionResource.php
+++ b/src/Resources/QuestionResource.php
@@ -57,21 +57,20 @@ class QuestionResource extends Resource
         return $form
             ->schema([
                 Forms\Components\TextInput::make('content')
+                    ->label('Question')
                     ->required(),
                 Forms\Components\Select::make('type')
                     ->required()
                     ->reactive()
                     ->options(config('filament-survey.question.types')),
-                Forms\Components\TextInput::make('order')
-                    ->numeric()
-                    ->required(),
                 Forms\Components\TagsInput::make('options')
                     ->placeholder('New option')
-                    ->helperText("Used for radio and multiselect types. Eg: ['Yes', 'No']")
+                    ->helperText("Used for radio and multiselect types. Press enter after each option")
+                    ->required(fn (Get $get) => $get('type') == 'radio' || $get('type') == 'multiselect')
                     ->visible(fn (Get $get) => $get('type') == 'radio' || $get('type') == 'multiselect'),
                 Forms\Components\TagsInput::make('rules')
                     ->placeholder('New rule')
-                    ->helperText("Validation rules. Eg: ['numeric', 'min:2', 'required']"),
+                    ->helperText("Validation rules. Eg: 'numeric', 'min:2', 'required'. Press Enter after each rule. see https://laravel.com/docs/11.x/validation#available-validation-rules for a full list of available rules"),
                 Forms\Components\Select::make('section_id')->label('Section')
                     ->options(fn (Livewire $livewire, ?Model $record) => ! empty($livewire->survey_id) ? Section::where('survey_id', $livewire->survey_id)->pluck('name', 'id') : ($record ? Section::where('id', $record->section_id)->pluck('name', 'id') : []))
                     ->helperText('To be available here, a survey should be added first on section.'),

--- a/src/Resources/QuestionResource.php
+++ b/src/Resources/QuestionResource.php
@@ -7,6 +7,7 @@ use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Resources\Concerns\Translatable;
 use Filament\Resources\Resource;
+use Filament\Tables\Actions\DeleteAction;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
@@ -93,6 +94,9 @@ class QuestionResource extends Resource
                     ->dateTime(),
                 Tables\Columns\TextColumn::make('updated_at')
                     ->dateTime(),
+            ])
+            ->actions([
+                DeleteAction::make(),
             ])
             ->filters([
                 //

--- a/src/Resources/SectionResource.php
+++ b/src/Resources/SectionResource.php
@@ -7,6 +7,7 @@ use Filament\Forms\Form;
 use Filament\Resources\Concerns\Translatable;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Actions\DeleteAction;
 use Filament\Tables\Table;
 use MattDaneshvar\Survey\Models\Section;
 use Tapp\FilamentSurvey\Resources\SectionResource\Pages;
@@ -68,6 +69,9 @@ class SectionResource extends Resource
                     ->dateTime(),
                 Tables\Columns\TextColumn::make('updated_at')
                     ->dateTime(),
+            ])
+            ->actions([
+                DeleteAction::make(),
             ])
             ->filters([
                 //

--- a/src/Resources/SurveyResource.php
+++ b/src/Resources/SurveyResource.php
@@ -3,19 +3,20 @@
 namespace Tapp\FilamentSurvey\Resources;
 
 use Filament\Forms;
-use Filament\Forms\Form;
-use Filament\Resources\Concerns\Translatable;
-use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Forms\Get;
+use Filament\Forms\Form;
+use Filament\Tables\Table;
+use Filament\Resources\Resource;
 use Filament\Tables\Actions\Action;
+use MattDaneshvar\Survey\Models\Survey;
 use Filament\Tables\Actions\DeleteAction;
 use Filament\Tables\Enums\ActionsPosition;
-use Filament\Forms\Get;
-use Filament\Tables\Table;
-use MattDaneshvar\Survey\Models\Survey;
-use Tapp\FilamentSurvey\Resources\QuestionResource\Pages as QuestionPages;
+use Filament\Resources\Concerns\Translatable;
 use Tapp\FilamentSurvey\Resources\SurveyResource\Pages;
 use Tapp\FilamentSurvey\Resources\SurveyResource\Widgets\Questions;
+use Tapp\FilamentSurvey\Resources\SurveyResource\RelationManagers\QuestionsRelationManager;
+use Tapp\FilamentSurvey\Resources\QuestionResource\Pages as QuestionPages;
 
 class SurveyResource extends Resource
 {
@@ -85,16 +86,12 @@ class SurveyResource extends Resource
                     ->label('Name (English)')
                     ->sortable()
                     ->searchable(),
-                Tables\Columns\TextColumn::make('settings'),
                 Tables\Columns\TextColumn::make('created_at')
                     ->dateTime(),
                 Tables\Columns\TextColumn::make('updated_at')
                     ->dateTime(),
             ])
             ->actions([
-                Action::make('CreateQuestion')
-                    ->url(fn (Survey $record): string => route('filament.admin.resources.surveys.create-question', $record->id))
-                    ->color('success'),
                 DeleteAction::make(),
             ])
             ->filters([
@@ -105,7 +102,7 @@ class SurveyResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
+            QuestionsRelationManager::class,
         ];
     }
 
@@ -114,7 +111,6 @@ class SurveyResource extends Resource
         return [
             'index' => Pages\ListSurveys::route('/'),
             'create' => Pages\CreateSurvey::route('/create'),
-            'create-question' => QuestionPages\CreateQuestion::route('/{survey_id}/create'),
             'edit' => Pages\EditSurvey::route('/{record}/edit'),
         ];
     }

--- a/src/Resources/SurveyResource.php
+++ b/src/Resources/SurveyResource.php
@@ -3,22 +3,22 @@
 namespace Tapp\FilamentSurvey\Resources;
 
 use Filament\Forms;
-use Filament\Tables;
-use Filament\Forms\Get;
 use Filament\Forms\Form;
-use Filament\Tables\Table;
+use Filament\Forms\Get;
+use Filament\Notifications\Notification;
+use Filament\Resources\Concerns\Translatable;
 use Filament\Resources\Resource;
+use Filament\Tables;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\BulkAction;
-use MattDaneshvar\Survey\Models\Survey;
-use Filament\Notifications\Notification;
 use Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Collection;
-use Filament\Resources\Concerns\Translatable;
+use MattDaneshvar\Survey\Models\Survey;
 use Tapp\FilamentSurvey\Jobs\SendExportSurveys;
 use Tapp\FilamentSurvey\Resources\SurveyResource\Pages;
-use Tapp\FilamentSurvey\Resources\SurveyResource\RelationManagers\SectionsRelationManager;
 use Tapp\FilamentSurvey\Resources\SurveyResource\RelationManagers\QuestionsRelationManager;
+use Tapp\FilamentSurvey\Resources\SurveyResource\RelationManagers\SectionsRelationManager;
 
 class SurveyResource extends Resource
 {

--- a/src/Resources/SurveyResource.php
+++ b/src/Resources/SurveyResource.php
@@ -8,7 +8,9 @@ use Filament\Resources\Concerns\Translatable;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\DeleteAction;
 use Filament\Tables\Enums\ActionsPosition;
+use Filament\Forms\Get;
 use Filament\Tables\Table;
 use MattDaneshvar\Survey\Models\Survey;
 use Tapp\FilamentSurvey\Resources\QuestionResource\Pages as QuestionPages;
@@ -57,8 +59,22 @@ class SurveyResource extends Resource
             ->schema([
                 Forms\Components\TextInput::make('name')
                     ->required(),
-                Forms\Components\TextInput::make('settings'),
-            ]);
+                Forms\Components\Checkbox::make('limit')
+                    ->label('Limit entries per participant?')
+                    ->live()
+                    ->inline(false),
+                Forms\Components\TextInput::make('limit_per_participant')
+                    ->default(1)
+                    ->visible(function (Get $get) {
+                        return $get('limit');
+                    })
+                    ->minValue(1)
+                    ->numeric(),
+                Forms\Components\Checkbox::make('allow_guests')
+                    ->label('Allow guest users to respond to survey?')
+                    ->inline(false),
+            ])
+            ->columns(1);
     }
 
     public static function table(Table $table): Table
@@ -66,7 +82,9 @@ class SurveyResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('name')
-                    ->label('Name (English)'),
+                    ->label('Name (English)')
+                    ->sortable()
+                    ->searchable(),
                 Tables\Columns\TextColumn::make('settings'),
                 Tables\Columns\TextColumn::make('created_at')
                     ->dateTime(),
@@ -77,7 +95,8 @@ class SurveyResource extends Resource
                 Action::make('CreateQuestion')
                     ->url(fn (Survey $record): string => route('filament.admin.resources.surveys.create-question', $record->id))
                     ->color('success'),
-            ], position: ActionsPosition::BeforeColumns)
+                DeleteAction::make(),
+            ])
             ->filters([
                 //
             ]);

--- a/src/Resources/SurveyResource.php
+++ b/src/Resources/SurveyResource.php
@@ -8,15 +8,11 @@ use Filament\Forms\Get;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
 use Filament\Resources\Resource;
-use Filament\Tables\Actions\Action;
 use MattDaneshvar\Survey\Models\Survey;
 use Filament\Tables\Actions\DeleteAction;
-use Filament\Tables\Enums\ActionsPosition;
 use Filament\Resources\Concerns\Translatable;
 use Tapp\FilamentSurvey\Resources\SurveyResource\Pages;
-use Tapp\FilamentSurvey\Resources\SurveyResource\Widgets\Questions;
 use Tapp\FilamentSurvey\Resources\SurveyResource\RelationManagers\QuestionsRelationManager;
-use Tapp\FilamentSurvey\Resources\QuestionResource\Pages as QuestionPages;
 use Tapp\FilamentSurvey\Resources\SurveyResource\RelationManagers\SectionsRelationManager;
 
 class SurveyResource extends Resource
@@ -103,8 +99,8 @@ class SurveyResource extends Resource
     public static function getRelations(): array
     {
         return [
-            QuestionsRelationManager::class,
             SectionsRelationManager::class,
+            QuestionsRelationManager::class,
         ];
     }
 
@@ -114,13 +110,6 @@ class SurveyResource extends Resource
             'index' => Pages\ListSurveys::route('/'),
             'create' => Pages\CreateSurvey::route('/create'),
             'edit' => Pages\EditSurvey::route('/{record}/edit'),
-        ];
-    }
-
-    public static function getWidgets(): array
-    {
-        return [
-            Questions::class,
         ];
     }
 }

--- a/src/Resources/SurveyResource.php
+++ b/src/Resources/SurveyResource.php
@@ -17,6 +17,7 @@ use Tapp\FilamentSurvey\Resources\SurveyResource\Pages;
 use Tapp\FilamentSurvey\Resources\SurveyResource\Widgets\Questions;
 use Tapp\FilamentSurvey\Resources\SurveyResource\RelationManagers\QuestionsRelationManager;
 use Tapp\FilamentSurvey\Resources\QuestionResource\Pages as QuestionPages;
+use Tapp\FilamentSurvey\Resources\SurveyResource\RelationManagers\SectionsRelationManager;
 
 class SurveyResource extends Resource
 {
@@ -103,6 +104,7 @@ class SurveyResource extends Resource
     {
         return [
             QuestionsRelationManager::class,
+            SectionsRelationManager::class,
         ];
     }
 

--- a/src/Resources/SurveyResource/Pages/CreateSurvey.php
+++ b/src/Resources/SurveyResource/Pages/CreateSurvey.php
@@ -3,6 +3,7 @@
 namespace Tapp\FilamentSurvey\Resources\SurveyResource\Pages;
 
 use Filament\Actions;
+use Illuminate\Database\Eloquent\Model;
 use Filament\Resources\Pages\CreateRecord;
 use Tapp\FilamentSurvey\Resources\SurveyResource;
 
@@ -17,5 +18,18 @@ class CreateSurvey extends CreateRecord
         return [
             Actions\LocaleSwitcher::make(),
         ];
+    }
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $settings = [
+            'accept-guest-entries' => $data['allow_guests'],
+            'limit-per-participant' => !$data['limit'] ? -1 : $data['limit_per_participant'],
+        ];
+
+        return static::getModel()::create([
+            'name' => $data['name'],
+            'settings' => $settings,
+        ]);
     }
 }

--- a/src/Resources/SurveyResource/Pages/EditSurvey.php
+++ b/src/Resources/SurveyResource/Pages/EditSurvey.php
@@ -5,6 +5,7 @@ namespace Tapp\FilamentSurvey\Resources\SurveyResource\Pages;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
 use Tapp\FilamentSurvey\Resources\SurveyResource;
+use Illuminate\Database\Eloquent\Model;
 
 class EditSurvey extends EditRecord
 {
@@ -24,5 +25,35 @@ class EditSurvey extends EditRecord
         return [
             Actions\LocaleSwitcher::make(),
         ];
+    }
+
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        $settings = $this->record->settings;
+
+        if ($settings) {
+            $data['limit'] = $settings['limit-per-participant'] > 0;      
+            $data['limit_per_participant'] = $settings['limit-per-participant'] ?? null;
+            $data['allow_guests'] = $settings['accept-guest-entries'];
+        }
+
+        $data['name'] = $this->record->name;
+
+        return $data;
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        $settings = [
+            'accept-guest-entries' => $data['allow_guests'],
+            'limit-per-participant' => !$data['limit'] ? -1 : $data['limit_per_participant'],
+        ];
+
+        $record->update([
+            'name' => $data['name'],
+            'settings' => $settings,
+        ]);
+ 
+        return $record;
     }
 }

--- a/src/Resources/SurveyResource/Pages/EditSurvey.php
+++ b/src/Resources/SurveyResource/Pages/EditSurvey.php
@@ -13,13 +13,6 @@ class EditSurvey extends EditRecord
 
     protected static string $resource = SurveyResource::class;
 
-    protected function getFooterWidgets(): array
-    {
-        return [
-            SurveyResource\Widgets\Questions::class,
-        ];
-    }
-
     protected function getHeaderActions(): array
     {
         return [

--- a/src/Resources/SurveyResource/Pages/ListSurveys.php
+++ b/src/Resources/SurveyResource/Pages/ListSurveys.php
@@ -3,6 +3,7 @@
 namespace Tapp\FilamentSurvey\Resources\SurveyResource\Pages;
 
 use Filament\Actions;
+use Filament\Actions\DeleteAction;
 use Filament\Notifications\Notification;
 use Filament\Pages\Actions\Action;
 use Filament\Resources\Pages\ListRecords;
@@ -20,6 +21,7 @@ class ListSurveys extends ListRecords
         $actions = parent::getActions();
 
         return array_merge($actions, [
+            DeleteAction::make(),
             Action::make(__('Export Answers'))
                 ->icon(config('filament-survey.actions.survey.export.icon'))
                 ->action('export'),

--- a/src/Resources/SurveyResource/RelationManagers/QuestionsRelationManager.php
+++ b/src/Resources/SurveyResource/RelationManagers/QuestionsRelationManager.php
@@ -76,6 +76,7 @@ class QuestionsRelationManager extends RelationManager
                 EditAction::make(),
                 DeleteAction::make(),
             ])
-            ->defaultSort('order');
+            ->defaultSort('order')
+            ->reorderable('order');
     }
 }

--- a/src/Resources/SurveyResource/RelationManagers/QuestionsRelationManager.php
+++ b/src/Resources/SurveyResource/RelationManagers/QuestionsRelationManager.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tapp\FilamentSurvey\Resources\SurveyResource\RelationManagers;
+
+use Filament\Forms;
+use Filament\Tables;
+use Filament\Forms\Get;
+use Filament\Forms\Form;
+use Filament\Tables\Table;
+use Livewire\Component as Livewire;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Actions\CreateAction;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Resources\RelationManagers\Concerns\Translatable;
+use MattDaneshvar\Survey\Models\Question;
+use MattDaneshvar\Survey\Models\Section;
+
+class QuestionsRelationManager extends RelationManager
+{
+    use Translatable;
+
+    public static function getTranslatableLocales(): array
+    {
+        return array_keys(config('filament-survey.languages'));
+    }
+
+    protected static string $relationship = 'questions';
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('content')
+                    ->label('Question')
+                    ->required(),
+                Forms\Components\Select::make('type')
+                    ->required()
+                    ->reactive()
+                    ->options(config('filament-survey.question.types')),
+                Forms\Components\TagsInput::make('options')
+                    ->placeholder('New option')
+                    ->helperText("Used for radio and multiselect types. Press enter after each option")
+                    ->required(fn (Get $get) => $get('type') == 'radio' || $get('type') == 'multiselect')
+                    ->visible(fn (Get $get) => $get('type') == 'radio' || $get('type') == 'multiselect'),
+                Forms\Components\TagsInput::make('rules')
+                    ->placeholder('New rule')
+                    ->helperText("Validation rules. Eg: 'numeric', 'min:2', 'required'. Press Enter after each rule. see https://laravel.com/docs/11.x/validation#available-validation-rules for a full list of available rules"),
+                Forms\Components\Select::make('section_id')->label('Section')
+                    ->options(fn () => Section::where('survey_id', $this->getOwnerRecord()->id)->pluck('name', 'id'))
+                    ->helperText('To be available here, a survey should be added first on section.'),
+            ]);
+    }
+ 
+    public function table(Table $table): Table
+    {
+        return $table
+            ->headerActions([
+                CreateAction::make(),
+            ])
+            ->columns([
+                Tables\Columns\TextColumn::make('content')
+                    ->label('Question')
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('type')
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('order')
+                    ->toggleable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('section.name'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->toggleable()
+                    ->dateTime(),
+            ])
+            ->actions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->defaultSort('order');
+    }
+}

--- a/src/Resources/SurveyResource/RelationManagers/QuestionsRelationManager.php
+++ b/src/Resources/SurveyResource/RelationManagers/QuestionsRelationManager.php
@@ -7,13 +7,11 @@ use Filament\Tables;
 use Filament\Forms\Get;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
-use Livewire\Component as Livewire;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Actions\DeleteAction;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Resources\RelationManagers\Concerns\Translatable;
-use MattDaneshvar\Survey\Models\Question;
 use MattDaneshvar\Survey\Models\Section;
 
 class QuestionsRelationManager extends RelationManager
@@ -47,8 +45,7 @@ class QuestionsRelationManager extends RelationManager
                     ->placeholder('New rule')
                     ->helperText("Validation rules. Eg: 'numeric', 'min:2', 'required'. Press Enter after each rule. see https://laravel.com/docs/11.x/validation#available-validation-rules for a full list of available rules"),
                 Forms\Components\Select::make('section_id')->label('Section')
-                    ->options(fn () => Section::where('survey_id', $this->getOwnerRecord()->id)->pluck('name', 'id'))
-                    ->helperText('To be available here, a survey should be added first on section.'),
+                    ->options(fn () => Section::where('survey_id', $this->getOwnerRecord()->id)->pluck('name', 'id')),
             ]);
     }
  

--- a/src/Resources/SurveyResource/RelationManagers/SectionsRelationManager.php
+++ b/src/Resources/SurveyResource/RelationManagers/SectionsRelationManager.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tapp\FilamentSurvey\Resources\SurveyResource\RelationManagers;
+
+use Filament\Forms;
+use Filament\Tables;
+use Filament\Forms\Get;
+use Filament\Forms\Form;
+use Filament\Tables\Table;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Actions\CreateAction;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Resources\RelationManagers\Concerns\Translatable;
+use MattDaneshvar\Survey\Models\Section;
+
+class SectionsRelationManager extends RelationManager
+{
+    use Translatable;
+
+    public static function getTranslatableLocales(): array
+    {
+        return array_keys(config('filament-survey.languages'));
+    }
+
+    protected static string $relationship = 'sections';
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('name')
+                    ->required(),
+            ]);
+    }
+ 
+    public function table(Table $table): Table
+    {
+        return $table
+            ->headerActions([
+                CreateAction::make(),
+            ])
+            ->columns([
+                Tables\Columns\TextColumn::make('name'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime(),
+            ])
+            ->actions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ]);
+    }
+}


### PR DESCRIPTION
#description
This PR restores the ability to delete Laravel-Survey records that was lost in the filament v3 upgrade, and also completely overhauls the creation flow for surveys, eliminating the need for question and section resources and bringing all functionality into the EditSurvey page.

#steps to test
1. remove SectionResource and QuestionResource from published filament-survey.php config
2. login to admin panel and play around with new survey features. Create a new survey, sections, and questions all in one place.
3. load view for survey entry to confirm everything is working on front end with new survey.
4. Test exports for surveys, both bulk and individual