### PR TITLE
feat: Add Support for Filament 3.2+ and Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,14 @@
         "issues": "https://github.com/TappNetwork/filament-survey/issues",
         "source": "https://github.com/TappNetwork/filament-survey"
     },
-    "require": {
-        "php": "^8.1",
-        "filament/filament": "^3.0-stable",
-        "filament/spatie-laravel-translatable-plugin": "^3.0-stable",
-        "maatwebsite/excel": "^3.1",
-        "spatie/eloquent-sortable": "^4.0",
-        "spatie/laravel-package-tools": "^1.9"
-    },
+   "require": {
+    "php": "^8.2",
+    "filament/filament": "^3.2",
+    "filament/spatie-laravel-translatable-plugin": "^3.2",
+    "maatwebsite/excel": "^3.1",
+    "spatie/eloquent-sortable": "^4.0.2",
+    "spatie/laravel-package-tools": "^1.16"
+},
     "require-dev": {
         "doctrine/dbal": "^3.6"
     },


### PR DESCRIPTION
### What is the problem?

The current package dependencies are constrained to older versions of Filament (e.g., `^3.0-stable`), which prevents its use in projects running on the latest versions of Filament (3.2+) and Laravel (11/12).

This PR is the second part of a larger update and is dependent on the corresponding compatibility update for the core `tappnetwork/laravel-survey` package.

### How does this PR solve the problem?

This Pull Request updates the `composer.json` file to align its dependencies with a modern Filament 3 and Laravel 12 stack.

The following changes were made:
- The required PHP version was updated to `^8.2`.
- Version constraints for `filament/filament` and `filament/spatie-laravel-translatable-plugin` were updated to `^3.2`.
- The `spatie/laravel-package-tools` dependency was updated to `^1.16` for better Laravel 12 support.
- *(Optional, add this if you fixed any code)* Additionally, breaking changes from the Filament version bump have been addressed in the source code.

### How can this be tested?

This PR must be tested alongside the corresponding PR for `tappnetwork/laravel-survey`.

1. Create a new Laravel 12 project with Filament 3.3 installed.
2. In the project's `composer.json`, add the `repositories` entries for **both** the forked `laravel-survey` and this `filament-survey` fork.
3. In the `require` section, point both `matt-daneshvar/laravel-survey` and `tapp/filament-survey` to their respective `dev-main` branches from your forks.
4. Run `composer update`.
5. Verify that the Survey resources appear in the Filament panel and that creating/editing a survey works without errors.

### Context

This PR should be reviewed and merged in conjunction with the compatibility update for the core `laravel-survey` package.

**Related PR:** (https://github.com/TappNetwork/laravel-survey/pull/5)